### PR TITLE
Fix: header params in URL cause '400 Bad Request'

### DIFF
--- a/src/com/basho/riakcs/client/impl/RiakCSClientImpl.java
+++ b/src/com/basho/riakcs/client/impl/RiakCSClientImpl.java
@@ -388,7 +388,7 @@ public class RiakCSClientImpl
 			CommunicationLayer comLayer= getCommunicationLayer();
 			
 			URL url= comLayer.generateCSUrl(bucketName, objectKey, EMPTY_STRING_MAP);
-			HttpURLConnection conn= comLayer.makeCall(CommunicationLayer.HttpMethod.GET, url, null, EMPTY_STRING_MAP);
+			HttpURLConnection conn= comLayer.makeCall(CommunicationLayer.HttpMethod.GET, url);
 	
 			object= extractMetaInfoForObject(objectKey, conn);
 	
@@ -426,7 +426,7 @@ public class RiakCSClientImpl
 			CommunicationLayer comLayer= getCommunicationLayer();
 			
 			URL url= comLayer.generateCSUrl(bucketName, objectKey, EMPTY_STRING_MAP);
-			HttpURLConnection conn= comLayer.makeCall(CommunicationLayer.HttpMethod.HEAD, url, null, EMPTY_STRING_MAP);
+			HttpURLConnection conn= comLayer.makeCall(CommunicationLayer.HttpMethod.HEAD, url);
 	
 			object= extractMetaInfoForObject(objectKey, conn);
 		
@@ -753,7 +753,7 @@ public class RiakCSClientImpl
 			CommunicationLayer comLayer= getCommunicationLayer();
 	
 			URL url= comLayer.generateCSUrl(path.toString());
-			HttpURLConnection connection= comLayer.makeCall(CommunicationLayer.HttpMethod.GET, url, null, EMPTY_STRING_MAP);
+			HttpURLConnection connection= comLayer.makeCall(CommunicationLayer.HttpMethod.GET, url);
 	
 			InputStreamReader inputStreamReader= new InputStreamReader(connection.getInputStream(), "UTF-8");
 			result= new JSONObject(new JSONTokener(inputStreamReader));
@@ -792,7 +792,7 @@ public class RiakCSClientImpl
 			CommunicationLayer comLayer= getCommunicationLayer();
 	
 			URL url= comLayer.generateCSUrl(path.toString());
-			HttpURLConnection connection= comLayer.makeCall(CommunicationLayer.HttpMethod.GET, url, null, EMPTY_STRING_MAP);
+			HttpURLConnection connection= comLayer.makeCall(CommunicationLayer.HttpMethod.GET, url);
 	
 			InputStreamReader inputStreamReader= new InputStreamReader(connection.getInputStream(), "UTF-8");
 			result= new JSONObject(new JSONTokener(inputStreamReader));


### PR DESCRIPTION
SUMMARY:
In some cases, header parameters are appended to the URL, causing HTTP
calls to the Riak CS server to fail.

DETAIL:
Four methods (getObject, getObjectInfo, getAccessStatistic, and
getStorageStatistic) contain the following code:

URL url= comLayer.generateCSUrl(bucketName, objectKey,
EMPTY_STRING_MAP);
HttpURLConnection conn=
comLayer.makeCall(CommunicationLayer.HttpMethod.GET, url, null,
EMPTY_STRING_MAP);

The first time this code is executed, the call succeeds. However, after
that, EMPTY_STRING_MAP is no longer empty (method makeCall has added
header info to it), and subsequent calls to any method that passes
EMPTY_STRING_MAP to generateCSUrl will result in a bad URL (with
headers appended to the URL) and, hence, failed HTTP calls.

The problem is fixed with a simple correction in each of the 4 methods:
- HttpURLConnection conn=
  comLayer.makeCall(CommunicationLayer.HttpMethod.GET, url, null,
  EMPTY_STRING_MAP);
- HttpURLConnection conn=
  comLayer.makeCall(CommunicationLayer.HttpMethod.GET, url);

The problem is illustrated by the logging below, which first shows a
successful call (before the execution of one of the aforementioned
methods), and a failed call. Note the header parameters that have been
appended to the URL the second time, leading to the error: 400 Bad
Request.

SUCCESS:

OUT REQUEST DESCRIPTION
OUT =======
OUT GET\n
OUT \n
OUT \n
OUT Thu, 11 Sep 2014 16:21:34 GMT\n
OUT /
OUT Authorization AWS MYACCESSKEY:odNaDSR0UeV4DQy+jPkm0yUH1wI=
OUT Host riakcs.mydomain.com
OUT Date Thu, 11 Sep 2014 16:21:34 GMT
OUT REQUEST
OUT =======
OUT Method : GET
OUT URI    : http://riakcs.mydomain.com
OUT Headers:
OUT   Date=Thu, 11 Sep 2014 16:21:34 GMT
OUT RESPONSE
OUT ========
OUT Status : 200 OK
OUT Headers:
OUT   null=HTTP/1.1 200 OK
OUT   Date=Thu, 11 Sep 2014 16:21:34 GMT
OUT   Content-Length=296
OUT   Content-Type=application/xml
OUT   Server=Riak CS
OUT Body:
OUT <?xml version="1.0" encoding="UTF-8" standalone="no"?>

FAILURE:

OUT REQUEST DESCRIPTION
OUT =======
OUT GET\n
OUT \n
OUT \n
OUT Thu, 11 Sep 2014 16:22:40 GMT\n
OUT /
OUT Authorization AWS MYACCESSKEY:G+Qt3znGtl1CjRFTXsZCNZeR3zo=
OUT Host riakcs.mydomain.com
OUT Date Thu, 11 Sep 2014 16:22:40 GMT
OUT REQUEST
OUT =======
OUT Method : GET
OUT URI
:http://riakcs.mydomain.com?Authorization=AWS+MYACCESSKEY%3AZ25yz8Hu4gXZ
OPBYQcZyRsIWGDc%3D
OUT      &Host=riakcs.mydomain.com
OUT      &Date=Thu%2C+11+Sep+2014+16%3A21%3A35+GMT
OUT Headers:
OUT   Date=Thu, 11 Sep 2014 16:22:40 GMT
OUT RESPONSE
OUT ========
OUT Status : 400 Bad Request
OUT Headers:
OUT   null=HTTP/1.1 400 Bad Request
OUT Body:
OUT 2014-09-11 16:22:40,350 ERROR | http-nio-62417-exec-3
|o.a.c.c.C.[Tomcat].[localhost].[/].[dispatcherServlet]
|Servlet.service() for servlet [dispatcherServlet] in context with
path[] threw exception [Request processing failed; nested exception is
com.basho.riakcs.client.api.RiakCSException: java.lang.Exception:
Received Error: 400] with root cause
OUT java.lang.Exception: Received Error: 400
OUT     at
com.basho.riakcs.client.impl.CommunicationLayer.makeCallImpl(Communicati
onLayer.java:227) ~[app/:na]
OUT     at
com.basho.riakcs.client.impl.CommunicationLayer.makeCall(CommunicationLa
yer.java:123) ~[app/:na]
OUT     at
com.basho.riakcs.client.impl.RiakCSClientImpl.listBuckets(RiakCSClientIm
pl.java:272) ~[app/:na]
